### PR TITLE
Fixed issue where a signing key is generated when trying to generate …

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -19,28 +19,28 @@ class Key implements Contract\CryptoKeyInterface
     const ENCRYPTION       =   4;
     const SIGNATURE        =   8;
     const ASYMMETRIC       =  16;
-    
+
     // SHORTCUTS:
     const CRYPTO_SECRETBOX =  5;
     const CRYPTO_AUTH      =  9;
     const CRYPTO_BOX       = 20;
     const CRYPTO_SIGN      = 24;
-    
+
     private $is_public_key = false;
     private $is_signing_key = false;
     private $is_asymmetric_key = false;
     private $key_material = '';
-    
+
     /**
      * Don't let this ever succeed
-     * 
+     *
      * @throws CryptoException\CannotCloneKey
      */
     public function __clone()
     {
         throw new CryptoException\CannotCloneKey;
     }
-    
+
     /**
      * @param string $keyMaterial - The actual key data
      * @param bool $public - Is this a public key?
@@ -54,7 +54,7 @@ class Key implements Contract\CryptoKeyInterface
         $public = \count($args) >= 1 ? $args[0] : false;
         $signing = \count($args) >= 2 ? $args[1] : false;
         $asymmetric = \count($args) >= 3 ? $args[2] : false;
-        
+
         $this->key_material = $keyMaterial;
         $this->is_public_key = $public;
         $this->is_signing_key = $signing;
@@ -64,7 +64,7 @@ class Key implements Contract\CryptoKeyInterface
         }
         $this->is_asymmetric_key = $asymmetric;
     }
-    
+
     /**
      * Make sure you wipe the key from memory on destruction
      */
@@ -75,7 +75,7 @@ class Key implements Contract\CryptoKeyInterface
             $this->key_material = null;
         }
     }
-    
+
     /**
      * Don't serialize
      */
@@ -83,10 +83,10 @@ class Key implements Contract\CryptoKeyInterface
     {
         throw new CryptoException\CannotSerializeKey;
     }
-    
+
     /**
      * Get public keys
-     * 
+     *
      * @return string
      */
     public function __toString()
@@ -95,10 +95,10 @@ class Key implements Contract\CryptoKeyInterface
             return $this->key_material;
         }
     }
-    
+
     /**
      * Derive an encryption key from a password and a salt
-     * 
+     *
      * @param string $password
      * @param string $salt
      * @param int $type
@@ -112,7 +112,7 @@ class Key implements Contract\CryptoKeyInterface
     ) {
         // Set this to true to flag a key as a signing key
         $signing = false;
-        
+
         /**
          * Are we doing public key cryptography?
          */
@@ -124,7 +124,7 @@ class Key implements Contract\CryptoKeyInterface
                 $secret_key = \Sodium\crypto_pwhash_scryptsalsa208sha256(
                     \Sodium\CRYPTO_BOX_SECRETKEYBYTES,
                     $password,
-                    $salt, 
+                    $salt,
                     \Sodium\CRYPTO_PWHASH_SCRYPTSALSA208SHA256_OPSLIMIT_INTERACTIVE,
                     \Sodium\CRYPTO_PWHASH_SCRYPTSALSA208SHA256_MEMLIMIT_INTERACTIVE
                 );
@@ -151,17 +151,17 @@ class Key implements Contract\CryptoKeyInterface
                     'Must specify encryption or authentication'
                 );
             }
-            
+
             // Let's return an array with two keys
             return [
                 new ASecretKey($secret_key, $signing), // Secret key
                 new APublicKey($public_key, $signing)  // Public key
             ];
-        } elseif ($type & self::SECRET_KEY !== 0) {
+        } elseif (($type & self::SECRET_KEY) !== 0) {
             /**
              * Are we doing encryption or authentication?
              */
-            if ($type & self::SIGNATURE !== 0) {
+            if (($type & self::SIGNATURE) !== 0) {
                 $signing = true;
                 $secret_key = \Sodium\crypto_pwhash_scryptsalsa208sha256(
                     \Sodium\CRYPTO_AUTH_KEYBYTES,
@@ -186,10 +186,10 @@ class Key implements Contract\CryptoKeyInterface
             );
         }
     }
-    
+
     /**
      * Load a key from a file
-     * 
+     *
      * @param string $filePath
      * @param int $type
      * @return array|\ParagonIE\Halite\Key
@@ -201,7 +201,7 @@ class Key implements Contract\CryptoKeyInterface
     ) {
         // Set this to true to flag a key as a signing key
         $signing = false;
-        
+
         /**
          * Are we doing public key cryptography?
          */
@@ -225,7 +225,7 @@ class Key implements Contract\CryptoKeyInterface
                     'Must specify encryption or authentication'
                 );
             }
-            
+
             // Let's return an array with two keys
             return [
                 new ASecretKey($secret_key, $signing), // Secret key
@@ -246,10 +246,10 @@ class Key implements Contract\CryptoKeyInterface
             );
         }
     }
-    
+
     /**
      * Generate a key
-     * 
+     *
      * @param int $type
      * @param &string $secret_key - Reference to optional variable to store secret key in
      * @return array|Key
@@ -260,7 +260,7 @@ class Key implements Contract\CryptoKeyInterface
     ) {
         // Set this to true to flag a key as a signing key
         $signing = false;
-        
+
         /**
          * Are we doing public key cryptography?
          */
@@ -284,10 +284,10 @@ class Key implements Contract\CryptoKeyInterface
                     'Must specify encryption or authentication'
                 );
             }
-            
+
             // Let's wipe our $kp variable
             \Sodium\memzero($kp);
-            
+
             // Let's return an array with two keys
             return [
                 new ASecretKey($secret_key, $signing), // Secret key
@@ -303,7 +303,7 @@ class Key implements Contract\CryptoKeyInterface
                 );
             } elseif ($type & self::SIGNATURE !== 0) {
                 $signing = true;
-                
+
                 // ...let it throw, let it throw!
                 $secret_key = \random_bytes(
                     \Sodium\CRYPTO_AUTH_KEYBYTES
@@ -316,10 +316,10 @@ class Key implements Contract\CryptoKeyInterface
             );
         }
     }
-    
+
     /**
      * Get the actual key material
-     * 
+     *
      * @return string
      * @throws CryptoException\CannotAccessKey
      */
@@ -327,60 +327,60 @@ class Key implements Contract\CryptoKeyInterface
     {
         return $this->key_material;
     }
-    
+
     /**
      * Is this a part of a key pair?
-     * 
+     *
      * @return bool
      */
     public function isAsymmetricKey()
     {
         return $this->is_asymmetric_key;
     }
-    
+
     /**
      * Is this a signing key?
-     * 
+     *
      * @return bool
      */
     public function isEncryptionKey()
     {
         return !$this->is_signing_key;
     }
-    
+
     /**
      * Is this a public key?
-     * 
+     *
      * @return bool
      */
     public function isPublicKey()
     {
         return $this->is_public_key;
     }
-    
+
     /**
      * Is this a secret key?
-     * 
+     *
      * @return bool
      */
     public function isSecretKey()
     {
         return !$this->is_public_key;
     }
-    
+
     /**
      * Is this a signing key?
-     * 
+     *
      * @return bool
      */
     public function isSigningKey()
     {
         return $this->is_signing_key;
     }
-    
+
     /**
      * Save a copy of the key to a file
-     * 
+     *
      * @param string $filePath
      * @return bool|int
      */

--- a/test/unit/KeyTest.php
+++ b/test/unit/KeyTest.php
@@ -24,7 +24,7 @@ class KeyTest extends PHPUnit_Framework_TestCase
             "\x36\x33\x95\x75\xde\xfb\x37\x08\x01\xa5\x42\x13\xbd\x54\x58\x2d"
         );
     }
-    
+
     public function testDeriveSigningKey()
     {
         list($sign_secret, $sign_public) = ASecretKey::deriveFromPassword(
@@ -33,11 +33,11 @@ class KeyTest extends PHPUnit_Framework_TestCase
             "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f",
             Key::CRYPTO_SIGN
         );
-        
+
         $this->assertTrue($sign_secret instanceof ASecretKey);
         $this->assertTrue($sign_public instanceof APublicKey);
-        
-        // Can this be used?        
+
+        // Can this be used?
         $message = 'This is a test message';
         $signed = Asymmetric::sign(
             $message,
@@ -46,11 +46,34 @@ class KeyTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(
             Asymmetric::verify($message, $sign_public, $signed)
         );
-        
+
         $this->assertEquals(
             $sign_public->get(),
             "\xfe\x1b\x09\x86\x45\xb7\x04\xf5\xc2\x7f\x62\xc8\x61\x67\xd6\x09".
             "\x03\x1d\x95\xa7\x94\x5c\xe6\xd5\x55\x96\xe3\x75\x03\x17\x88\x34"
         );
+    }
+
+    public function testDeriveEncryptingKey()
+    {
+        $enc_secret = ASecretKey::deriveFromPassword(
+            'apple',
+            "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f".
+            "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f",
+            Key::CRYPTO_SECRETBOX
+        );
+
+        $this->assertTrue($enc_secret instanceof SecretKey);
+
+        $this->assertFalse($enc_secret->isAsymmetricKey());
+
+        $this->assertFalse($enc_secret->isPublicKey());
+
+        $this->assertFalse($enc_secret->isSigningKey());
+
+        $this->assertTrue($enc_secret->isSecretKey());
+
+        $this->assertTrue($enc_secret->isEncryptionKey());
+
     }
 }


### PR DESCRIPTION
…a symmetric encryption key with Key::deriveFromPassword

Added missing parenthesis in deriveFromPassword.  Added unit test for issue.

Fixes paragonie/halite#10

I just noticed the line endings changed.  Sorry about that.