### PR TITLE
add docs for saving key to hex string

### DIFF
--- a/doc/Basic.md
+++ b/doc/Basic.md
@@ -66,6 +66,18 @@ Later, you can load it like so:
 $enc_key = \ParagonIE\Halite\KeyFactory::loadEncryptionKey('/path/to/encryption.key');
 ```
 
+Or if you want to store it in a string
+
+```php
+$key_hex = KeyFactory::export($enc_key)->getString();
+```
+
+and get it back later
+
+```php
+$enc_key = KeyFactory::importEncryptionKey(new HiddenString($key_hex));
+```
+
 --------------------------------------------------------------------------------
 
 **Encryption** should be rather straightforward:


### PR DESCRIPTION
I must be low on coffee or something. It took me quite a while to figure out how to save a key to a hex string (eg to store in a .env file). Added docs for others who may be having a sleepy monday