### PR TITLE
Decrypting a file to php://output is not allowed by MutableFile

### DIFF
--- a/src/Stream/MutableFile.php
+++ b/src/Stream/MutableFile.php
@@ -28,7 +28,7 @@ use ParagonIE\Halite\Alerts\{
  */
 class MutableFile implements StreamInterface
 {
-    const ALLOWED_MODES = ['r+b', 'w+b', 'cb', 'c+b'];
+    const ALLOWED_MODES = ['r+b', 'w+b', 'cb', 'c+b', 'wb'];
     const CHUNK = 8192; // PHP's fread() buffer is set to 8192 by default
 
     /**

--- a/test/unit/FileTest.php
+++ b/test/unit/FileTest.php
@@ -715,4 +715,35 @@ final class FileTest extends TestCase
         );
         $this->assertTrue(\file_exists(__DIR__.'/tmp/empty116.encrypted.txt'));
     }
+
+    public function testOutputToOutputbuffer()
+    {
+        $stream = fopen('php://output', 'wb');
+
+        touch(__DIR__.'/tmp/paragon_avatar.encrypted.png');
+        chmod(__DIR__.'/tmp/paragon_avatar.encrypted.png', 0777);
+
+        $key = new EncryptionKey(
+            new HiddenString(\str_repeat('B', 32))
+        );
+        File::encrypt(
+            __DIR__.'/tmp/paragon_avatar.png',
+            __DIR__.'/tmp/paragon_avatar.encrypted.png',
+            $key
+        );
+
+        ob_start();
+        File::decrypt(
+            __DIR__.'/tmp/paragon_avatar.encrypted.png',
+            $stream,
+            $key
+        );
+        $contents = ob_get_clean();
+
+        $this->assertSame(
+            hash_file('sha256', __DIR__.'/tmp/paragon_avatar.png'),
+            hash('sha256', $contents)
+        );
+        unlink(__DIR__.'/tmp/paragon_avatar.encrypted.png');
+    }
 }


### PR DESCRIPTION
It complains that 'wb' is no valid mode, however when wb is added all tests
still pass.

I use this to serve the contents of the encrypted file directly to the user without having to decrypt it to a temp file on disk first.