### PR TITLE
Updated comment to refer to Argon2id, not Argon2i

### DIFF
--- a/src/Password.php
+++ b/src/Password.php
@@ -111,7 +111,7 @@ final class Password
             $config->ENCODING
         )->getString();
 
-        // Upon successful decryption, verify that we're using Argon2i
+        // Upon successful decryption, verify that we're using Argon2id
         if (!\hash_equals(
             Binary::safeSubstr($hash_str, 0, 10),
             \SODIUM_CRYPTO_PWHASH_STRPREFIX


### PR DESCRIPTION
The code checks for use of Argon2id now and not the previous algorithm of Argon2i so I updated the text to indicate same.