### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -103,7 +103,7 @@ final class File
      */
     public static function checksum(
         string|ReadonlyFile $filePath,
-        Key $key = null,
+        ?Key $key = null,
         bool|string $encoding = Halite::ENCODE_BASE64URLSAFE
     ): string {
         if ($filePath instanceof ReadOnlyFile) {
@@ -593,7 +593,7 @@ final class File
      */
     protected static function checksumData(
         StreamInterface $fileStream,
-        Key $key = null,
+        ?Key $key = null,
         string|bool $encoding = Halite::ENCODE_BASE64URLSAFE
     ): string {
         $config = self::getConfig(

--- a/src/Stream/ReadOnlyFile.php
+++ b/src/Stream/ReadOnlyFile.php
@@ -78,7 +78,7 @@ class ReadOnlyFile implements StreamInterface
      * @throws TypeError
      * @psalm-suppress RedundantConditionGivenDocblockType
      */
-    public function __construct($file, Key $key = null)
+    public function __construct($file, ?Key $key = null)
     {
         if (is_string($file)) {
             if (!is_readable($file)) {


### PR DESCRIPTION
Fixes 3 PHP 8.4 deprecations due to implicit nullables:

```
Deprecated: ParagonIE\Halite\Stream\ReadOnlyFile::__construct(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /data/vendor/paragonie/halite/src/Stream/ReadOnlyFile.php on line 81

Deprecated: ParagonIE\Halite\File::checksum(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /data/vendor/paragonie/halite/src/File.php on line 104

Deprecated: ParagonIE\Halite\File::checksumData(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /data/vendor/paragonie/halite/src/File.php on line 594
```