### PR TITLE
Replace all `http://` links with the `https://` URL they redirect to

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/src/Alerts/CannotCloneKey.php
+++ b/src/Alerts/CannotCloneKey.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class CannotCloneKey extends HaliteAlert implements HaliteAlertInterface
 {    

--- a/src/Alerts/CannotPerformOperation.php
+++ b/src/Alerts/CannotPerformOperation.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class CannotPerformOperation extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/CannotSerializeKey.php
+++ b/src/Alerts/CannotSerializeKey.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class CannotSerializeKey extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/ConfigDirectiveNotFound.php
+++ b/src/Alerts/ConfigDirectiveNotFound.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class ConfigDirectiveNotFound extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/FileAccessDenied.php
+++ b/src/Alerts/FileAccessDenied.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class FileAccessDenied extends FileError implements HaliteAlertInterface
 {

--- a/src/Alerts/FileError.php
+++ b/src/Alerts/FileError.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class FileError extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/FileModified.php
+++ b/src/Alerts/FileModified.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class FileModified extends FileError implements HaliteAlertInterface
 {

--- a/src/Alerts/HaliteAlert.php
+++ b/src/Alerts/HaliteAlert.php
@@ -11,7 +11,7 @@ use Exception;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class HaliteAlert extends Exception implements HaliteAlertInterface
 {

--- a/src/Alerts/HaliteAlertInterface.php
+++ b/src/Alerts/HaliteAlertInterface.php
@@ -11,7 +11,7 @@ use Throwable;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 interface HaliteAlertInterface extends Throwable
 {

--- a/src/Alerts/InvalidDigestLength.php
+++ b/src/Alerts/InvalidDigestLength.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidDigestLength extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/InvalidFlags.php
+++ b/src/Alerts/InvalidFlags.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidFlags extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/InvalidKey.php
+++ b/src/Alerts/InvalidKey.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidKey extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/InvalidMessage.php
+++ b/src/Alerts/InvalidMessage.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidMessage extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/InvalidSalt.php
+++ b/src/Alerts/InvalidSalt.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidSalt extends HaliteAlert implements HaliteAlertInterface
 { 

--- a/src/Alerts/InvalidSignature.php
+++ b/src/Alerts/InvalidSignature.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidSignature extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Alerts/InvalidType.php
+++ b/src/Alerts/InvalidType.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Halite\Alerts;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class InvalidType extends HaliteAlert implements HaliteAlertInterface
 {

--- a/src/Asymmetric/Config.php
+++ b/src/Asymmetric/Config.php
@@ -16,13 +16,13 @@ use ParagonIE\Halite\{
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Config extends BaseConfig
 {

--- a/src/Asymmetric/Crypto.php
+++ b/src/Asymmetric/Crypto.php
@@ -44,13 +44,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Crypto
 {

--- a/src/Asymmetric/EncryptionPublicKey.php
+++ b/src/Asymmetric/EncryptionPublicKey.php
@@ -14,7 +14,7 @@ use function sprintf;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class EncryptionPublicKey extends PublicKey
 {

--- a/src/Asymmetric/EncryptionSecretKey.php
+++ b/src/Asymmetric/EncryptionSecretKey.php
@@ -18,7 +18,7 @@ use function
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class EncryptionSecretKey extends SecretKey
 {

--- a/src/Asymmetric/PublicKey.php
+++ b/src/Asymmetric/PublicKey.php
@@ -12,7 +12,7 @@ use TypeError;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class PublicKey extends Key
 {

--- a/src/Asymmetric/SecretKey.php
+++ b/src/Asymmetric/SecretKey.php
@@ -12,7 +12,7 @@ use TypeError;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class SecretKey extends Key
 {

--- a/src/Asymmetric/SignaturePublicKey.php
+++ b/src/Asymmetric/SignaturePublicKey.php
@@ -18,7 +18,7 @@ use function
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class SignaturePublicKey extends PublicKey
 {

--- a/src/Asymmetric/SignatureSecretKey.php
+++ b/src/Asymmetric/SignatureSecretKey.php
@@ -21,7 +21,7 @@ use function
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class SignatureSecretKey extends SecretKey
 {

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,13 +13,13 @@ use function array_key_exists;
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  *
  * @property string|bool $ENCODING
  *

--- a/src/Contract/StreamInterface.php
+++ b/src/Contract/StreamInterface.php
@@ -15,13 +15,13 @@ use ParagonIE\Halite\Alerts\{
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Contract
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 interface StreamInterface
 {

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -37,13 +37,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  *
  * @codeCoverageIgnore
  */

--- a/src/EncryptionKeyPair.php
+++ b/src/EncryptionKeyPair.php
@@ -17,13 +17,13 @@ use ParagonIE\HiddenString\HiddenString;
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class EncryptionKeyPair extends KeyPair
 {

--- a/src/File.php
+++ b/src/File.php
@@ -60,13 +60,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class File
 {

--- a/src/Halite.php
+++ b/src/Halite.php
@@ -33,13 +33,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Halite
 {

--- a/src/Key.php
+++ b/src/Key.php
@@ -17,13 +17,13 @@ use TypeError;
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class Key
 {

--- a/src/KeyFactory.php
+++ b/src/KeyFactory.php
@@ -64,13 +64,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class KeyFactory
 {

--- a/src/KeyPair.php
+++ b/src/KeyPair.php
@@ -15,13 +15,13 @@ use ParagonIE\Halite\Asymmetric\{
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class KeyPair
 {

--- a/src/Password.php
+++ b/src/Password.php
@@ -36,13 +36,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Password
 {

--- a/src/SignatureKeyPair.php
+++ b/src/SignatureKeyPair.php
@@ -26,13 +26,13 @@ use function count;
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class SignatureKeyPair extends KeyPair
 {

--- a/src/Stream/MutableFile.php
+++ b/src/Stream/MutableFile.php
@@ -38,13 +38,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Stream
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class MutableFile implements StreamInterface
 {

--- a/src/Stream/ReadOnlyFile.php
+++ b/src/Stream/ReadOnlyFile.php
@@ -40,13 +40,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Stream
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class ReadOnlyFile implements StreamInterface
 {

--- a/src/Structure/MerkleTree.php
+++ b/src/Structure/MerkleTree.php
@@ -27,13 +27,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Structure
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class MerkleTree
 {

--- a/src/Structure/Node.php
+++ b/src/Structure/Node.php
@@ -14,13 +14,13 @@ use const SODIUM_CRYPTO_GENERICHASH_BYTES;
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Structure
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class Node
 {

--- a/src/Structure/TrimmedMerkleTree.php
+++ b/src/Structure/TrimmedMerkleTree.php
@@ -23,13 +23,13 @@ use function count;
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Structure
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class TrimmedMerkleTree extends MerkleTree
 {

--- a/src/Symmetric/AuthenticationKey.php
+++ b/src/Symmetric/AuthenticationKey.php
@@ -15,7 +15,7 @@ use function sprintf;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class AuthenticationKey extends SecretKey
 {

--- a/src/Symmetric/Config.php
+++ b/src/Symmetric/Config.php
@@ -20,13 +20,13 @@ use const
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Config extends BaseConfig
 {

--- a/src/Symmetric/Crypto.php
+++ b/src/Symmetric/Crypto.php
@@ -44,13 +44,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Crypto
 {

--- a/src/Symmetric/EncryptionKey.php
+++ b/src/Symmetric/EncryptionKey.php
@@ -15,7 +15,7 @@ use function sprintf;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class EncryptionKey extends SecretKey
 {

--- a/src/Symmetric/SecretKey.php
+++ b/src/Symmetric/SecretKey.php
@@ -10,7 +10,7 @@ use ParagonIE\Halite\Key;
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 class SecretKey extends Key
 {

--- a/src/Util.php
+++ b/src/Util.php
@@ -41,13 +41,13 @@ use function
  * This library makes heavy use of return-type declarations,
  * which are a PHP 7 only feature. Read more about them here:
  *
- * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @ref https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
  * @package ParagonIE\Halite
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
  */
 final class Util
 {
@@ -124,7 +124,7 @@ final class Util
 
     /**
      * Use a derivative of HKDF to derive multiple keys from one.
-     * http://tools.ietf.org/html/rfc5869
+     * https://datatracker.ietf.org/doc/html/rfc5869
      *
      * This is a variant from hash_hkdf() and instead uses BLAKE2b provided by
      * libsodium.

--- a/test/unit/AsymmetricTest.php
+++ b/test/unit/AsymmetricTest.php
@@ -331,7 +331,7 @@ final class AsymmetricTest extends TestCase
         $alice = KeyFactory::generateSignatureKeyPair();
         $bob = KeyFactory::generateEncryptionKeyPair();
 
-        // http://time.com/4261796/tim-cook-transcript/
+        // https://time.com/4261796/tim-cook-transcript/
         $message = new HiddenString(
             'When I think of civil liberties I think of the founding principles of the country. ' .
             'The freedoms that are in the First Amendment. But also the fundamental right to privacy.'
@@ -374,7 +374,7 @@ final class AsymmetricTest extends TestCase
         $alice = KeyFactory::generateSignatureKeyPair();
         $bob = KeyFactory::generateEncryptionKeyPair();
 
-        // http://time.com/4261796/tim-cook-transcript/
+        // https://time.com/4261796/tim-cook-transcript/
         $junk = new HiddenString(
             // Instead of a signature, it's 64 random bytes
             random_bytes(SODIUM_CRYPTO_SIGN_BYTES) .
@@ -397,7 +397,7 @@ final class AsymmetricTest extends TestCase
             $this->assertInstanceOf(CryptoException\InvalidSignature::class, $ex);
         }
 
-        // http://time.com/4261796/tim-cook-transcript/
+        // https://time.com/4261796/tim-cook-transcript/
         $message = new HiddenString(
             'When I think of civil liberties I think of the founding principles of the country. ' .
             'The freedoms that are in the First Amendment. But also the fundamental right to privacy.'

--- a/test/unit/UtilTest.php
+++ b/test/unit/UtilTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  * @category   HaliteTest
  * @package    Halite
  * @author     Stefanie Schmidt <stefanie@reneschmidt.de>
- * @license    http://opensource.org/licenses/GPL-3.0 GPL 3
+ * @license    https://opensource.org/license/GPL-3.0 GPL 3
  * @link       https://paragonie.com/project/halite
  */
 final class UtilTest extends TestCase


### PR DESCRIPTION
Possibly we don't want to update the one in the license file, if we want the text to be byte for byte identical.