### PR TITLE
Forward compatibility with v5

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm name="Halite Psalm Configuration"
        useDocblockTypes="true"
-       totallyTyped="true">
+>
     <projectFiles>
         <directory name="./src" />
     </projectFiles>
@@ -11,6 +11,8 @@
         <RedundantCondition errorLevel="suppress" />
         <RedundantConditionGivenDocblockType errorLevel="suppress" />
 
+        <TypeDoesNotContainType errorLevel="info" />
+        <ArgumentTypeCoercion errorLevel="info" />
         <RedundantCast errorLevel="info" />
         <NonInvariantDocblockPropertyType errorLevel="info" />
     </issueHandlers>

--- a/src/Asymmetric/Config.php
+++ b/src/Asymmetric/Config.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Halite\Asymmetric;
+
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\Halite\Alerts\InvalidMessage;
+use ParagonIE\Halite\{
+    Config as BaseConfig,
+    Halite,
+    Util
+};
+
+/**
+ * Class Config
+ *
+ * This library makes heavy use of return-type declarations,
+ * which are a PHP 7 only feature. Read more about them here:
+ *
+ * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ *
+ * @package ParagonIE\Halite\Asymmetric
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * @property string|bool ENCODING
+ * @property string HASH_DOMAIN_SEPARATION
+ * @property bool HASH_SCALARMULT
+ */
+final class Config extends BaseConfig
+{
+    /**
+     * Get the configuration
+     *
+     * @param string $header
+     * @param string $mode
+     * @return self
+     *
+     * @throws InvalidMessage
+     */
+    public static function getConfig(
+        string $header,
+        string $mode = 'encrypt'
+    ): self {
+        if (Binary::safeStrlen($header) < Halite::VERSION_TAG_LEN) {
+            throw new InvalidMessage(
+                'Invalid version tag'
+            );
+        }
+        /*
+         * We can safely omit the check on the first two bytes since
+         * this is checked elsewhere. This is just a best-effort to
+         * obtain the asymmetric configuration
+         */
+        $major = Util::chrToInt($header[2]);
+        $minor = Util::chrToInt($header[3]);
+        if ($mode === 'encrypt') {
+            return new Config(
+                self::getConfigEncrypt($major, $minor)
+            );
+        }
+        throw new InvalidMessage(
+            'Invalid configuration mode: '.$mode
+        );
+    }
+
+    /**
+     * Get the configuration for encrypt operations
+     *
+     * @param int $major
+     * @param int $minor
+     * @return array
+     * @throws InvalidMessage
+     */
+    public static function getConfigEncrypt(int $major, int $minor): array
+    {
+        if ($major === 5) {
+            switch ($minor) {
+                case 0:
+                    return [
+                        'ENCODING' => Halite::ENCODE_BASE64URLSAFE,
+                        'HASH_DOMAIN_SEPARATION' => 'HaliteVersion5X25519SharedSecret',
+                        'HASH_SCALARMULT' => true,
+                    ];
+            }
+        }
+        if ($major === 4 || $major === 3) {
+            switch ($minor) {
+                case 0:
+                    return [
+                        'ENCODING' => Halite::ENCODE_BASE64URLSAFE,
+                        'HASH_DOMAIN_SEPARATION' => '',
+                        'HASH_SCALARMULT' => false,
+                    ];
+            }
+        }
+        throw new InvalidMessage(
+            'Invalid version tag'
+        );
+    }
+}

--- a/src/Asymmetric/Crypto.php
+++ b/src/Asymmetric/Crypto.php
@@ -511,7 +511,7 @@ final class Crypto
      */
     public static function getAsymmetricConfig(
         string $ciphertext,
-        string|bool $encoding = Halite::ENCODE_BASE64URLSAFE
+        $encoding = Halite::ENCODE_BASE64URLSAFE
     ): Config {
         $decoder = Halite::chooseEncoder($encoding, true);
         if (is_callable($decoder)) {

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -147,8 +147,6 @@ final class Cookie
      * @throws InvalidMessage
      * @throws InvalidType
      * @throws \TypeError
-     *
-     * @psalm-suppress InvalidArgument PHP version incompatibilities
      * @psalm-suppress MixedArgument
      */
     public function store(

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -147,6 +147,8 @@ final class Cookie
      * @throws InvalidMessage
      * @throws InvalidType
      * @throws \TypeError
+     *
+     * @psalm-suppress InvalidArgument PHP version incompatibilities
      * @psalm-suppress MixedArgument
      */
     public function store(

--- a/src/Halite.php
+++ b/src/Halite.php
@@ -44,6 +44,7 @@ final class Halite
 
     /* Raw bytes (decoded) of the underlying ciphertext */
     const VERSION_TAG_LEN      = 4;
+    const VERSION_5_PREFIX     = 'MUIFA';
     const VERSION_PREFIX       = 'MUIEA';
     const VERSION_OLD_PREFIX   = 'MUIDA';
 

--- a/src/Password.php
+++ b/src/Password.php
@@ -161,6 +161,8 @@ final class Password
             );
         }
         if (
+            \hash_equals(Binary::safeSubstr($stored, 0, 5), Halite::VERSION_5_PREFIX)
+                ||
             \hash_equals(Binary::safeSubstr($stored, 0, 5), Halite::VERSION_PREFIX)
                 ||
             \hash_equals(Binary::safeSubstr($stored, 0, 5), Halite::VERSION_OLD_PREFIX)

--- a/src/Symmetric/Config.php
+++ b/src/Symmetric/Config.php
@@ -76,6 +76,25 @@ final class Config extends BaseConfig
      */
     public static function getConfigEncrypt(int $major, int $minor): array
     {
+        if ($major === 5) {
+            switch ($minor) {
+                case 0:
+                    return [
+                        'ENCODING' => Halite::ENCODE_BASE64URLSAFE,
+                        'SHORTEST_CIPHERTEXT_LENGTH' => 124,
+                        'NONCE_BYTES' => SODIUM_CRYPTO_STREAM_NONCEBYTES,
+                        'HKDF_SALT_LEN' => 32,
+                        'ENC_ALGO' => 'XChaCha20',
+                        'USE_PAE' => true,
+                        'MAC_ALGO' => 'BLAKE2b',
+                        'MAC_SIZE' => SODIUM_CRYPTO_GENERICHASH_BYTES_MAX,
+                        'HKDF_USE_INFO' => true,
+                        'HKDF_SBOX' => 'Halite|EncryptionKey',
+                        'HKDF_AUTH' => 'AuthenticationKeyFor_|Halite'
+                    ];
+            }
+        }
+
         if ($major === 3 || $major === 4) {
             switch ($minor) {
                 case 0:
@@ -84,8 +103,11 @@ final class Config extends BaseConfig
                         'SHORTEST_CIPHERTEXT_LENGTH' => 124,
                         'NONCE_BYTES' => \SODIUM_CRYPTO_STREAM_NONCEBYTES,
                         'HKDF_SALT_LEN' => 32,
+                        'ENC_ALGO' => 'XSalsa20', // ?
+                        'USE_PAE' => false,
                         'MAC_ALGO' => 'BLAKE2b',
                         'MAC_SIZE' => \SODIUM_CRYPTO_GENERICHASH_BYTES_MAX,
+                        'HKDF_USE_INFO' => false, // ?
                         'HKDF_SBOX' => 'Halite|EncryptionKey',
                         'HKDF_AUTH' => 'AuthenticationKeyFor_|Halite'
                     ];
@@ -106,14 +128,16 @@ final class Config extends BaseConfig
      */
     public static function getConfigAuth(int $major, int $minor): array
     {
-        if ($major === 3 || $major === 4) {
+        if ($major === 3 || $major === 4 || $major === 5) {
             switch ($minor) {
                 case 0:
                     return [
+                        'USE_PAE' => $major >= 5,
                         'HKDF_SALT_LEN' => 32,
                         'MAC_ALGO' => 'BLAKE2b',
                         'MAC_SIZE' => \SODIUM_CRYPTO_GENERICHASH_BYTES_MAX,
                         'PUBLICKEY_BYTES' => \SODIUM_CRYPTO_BOX_PUBLICKEYBYTES,
+                        'HKDF_USE_INFO' => $major > 4,
                         'HKDF_SBOX' => 'Halite|EncryptionKey',
                         'HKDF_AUTH' => 'AuthenticationKeyFor_|Halite'
                     ];

--- a/src/Util.php
+++ b/src/Util.php
@@ -11,6 +11,9 @@ use ParagonIE\Halite\Alerts\{
     InvalidDigestLength,
     InvalidType
 };
+use ParagonIE\Halite\Symmetric\EncryptionKey;
+use SodiumException;
+use TypeError;
 
 /**
  * Class Util
@@ -219,6 +222,23 @@ final class Util
     }
 
     /**
+     * Pre-authentication encoding
+     *
+     * @param string ...$pieces
+     *
+     * @return string
+     */
+    public static function PAE(string ...$pieces): string
+    {
+        $out = [];
+        $out[] = pack('P', count($pieces));
+        foreach ($pieces as $piece) {
+            $out[] = pack('P', Binary::safeStrlen($piece)) . $piece;
+        }
+        return implode($out);
+    }
+
+    /**
      * Wrapper around SODIUM_CRypto_generichash()
      *
      * Expects a key (binary string).
@@ -253,6 +273,66 @@ final class Util
             );
         }
         return \sodium_crypto_generichash($input, $key, $length);
+    }
+
+    /**
+     * Split a key (using HKDF-BLAKE2b instead of HKDF-HMAC-*)
+     *
+     * @param EncryptionKey $master
+     * @param string $salt
+     * @param Config $config
+     *
+     * @return string[]
+     *
+     * @throws CannotPerformOperation
+     * @throws InvalidDigestLength
+     * @throws SodiumException
+     * @throws TypeError
+     */
+    public static function splitKeys(
+        EncryptionKey $master,
+        string $salt,
+        Config $config
+    ): array {
+        $binary = $master->getRawKeyMaterial();
+
+        /*
+         * From Halite version 5, we use the HKDF info parameter instead of the salt.
+         * This does two things:
+         *
+         * 1. It allows us to use the HKDF security definition (which is stronger than a PRF)
+         * 2. It allows us to reuse the intermediary step and make key derivation faster.
+         */
+        if ($config->HKDF_USE_INFO) {
+            $prk = self::raw_keyed_hash(
+                $binary,
+                str_repeat("\x00", SODIUM_CRYPTO_GENERICHASH_KEYBYTES)
+            );
+            $return = [
+                self::raw_keyed_hash(((string) $config->HKDF_SBOX) . $salt . "\x01", $prk),
+                self::raw_keyed_hash(((string) $config->HKDF_AUTH) . $salt . "\x01", $prk)
+            ];
+            self::memzero($prk);
+            return $return;
+        }
+
+        /*
+         * Halite 4 and blow used this strategy:
+         */
+        return [
+            Util::hkdfBlake2b(
+                $binary,
+                SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
+                (string) $config->HKDF_SBOX,
+                $salt
+            ),
+            Util::hkdfBlake2b(
+                $binary,
+                SODIUM_CRYPTO_AUTH_KEYBYTES,
+                (string) $config->HKDF_AUTH,
+                $salt
+            )
+        ];
     }
 
     /**

--- a/test/unit/ForwardCompatibilityTest.php
+++ b/test/unit/ForwardCompatibilityTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace unit;
+
+use ParagonIE\Halite\Asymmetric\Crypto as AsymmetricCrypto;
+use ParagonIE\Halite\Asymmetric\EncryptionSecretKey;
+use ParagonIE\Halite\EncryptionKeyPair;
+use ParagonIE\Halite\Symmetric\EncryptionKey;
+use ParagonIE\HiddenString\HiddenString;
+use ParagonIE\Halite\Symmetric\Crypto as SymmetricCrypto;
+use PHPUnit\Framework\TestCase;
+
+final class ForwardCompatibilityTest extends TestCase
+{
+    public function testDecryptV5(): void
+    {
+        $encryptionKeyPairV5 = new EncryptionKeyPair(
+            new EncryptionSecretKey(
+                new HiddenString(\hex2bin('37d90f79b3c283d23431417483b1c97c8d745f874eef9ffe370d1acbe674162a'))
+            )
+        );
+
+        $decryptionKeyPair = new EncryptionKeyPair(
+            new EncryptionSecretKey(
+                new HiddenString(\hex2bin('f601b26d42b3b6b387928b0e76fd5e9a62b2e64b131d2b033d01f02abd5f0fc2'))
+            )
+        );
+
+        $asymmetric = 'MUIFAOOhCfwkfuthDoJ5BYIPSbD-CUN1WhuhNFcv83MU-o8UCksRNHlVfKA4mD_lopid8N7FfBKik5Qfungo-rgC201gUiR_EZ9G6ilnz7j3jV6egSv00OVs7GruP3Pb0-7bV4ye6Kru2u2J__GeVs9xFLbVLia5-UADkYPDOQ5Z';
+        $symmetric = 'MUIFACctAVGUcrAmOrQksMG7zI_zPawdW521kFstnbEB43S_QR6oXvEmgZPatK2SKfzmfYacrhpbpNlfgFdev5sypPRZAuu6sFjfVezctpQfvmyZqh2D2HVCkVamRve03Zq7fcU4uMTbdIA4NClAo03RCHqnDNHnpi0wCTl8A_tf';
+
+        $this->assertSame(
+            'marko',
+            AsymmetricCrypto::decrypt(
+                $asymmetric,
+                $decryptionKeyPair->getSecretKey(),
+                $encryptionKeyPairV5->getPublicKey()
+            )->getString()
+        );
+
+        $this->assertSame(
+            'marko',
+            SymmetricCrypto::decrypt(
+                $symmetric,
+                new EncryptionKey(new HiddenString(str_repeat('A', 32)))
+            )->getString()
+        );
+    }
+}

--- a/test/unit/RemoteStream.php
+++ b/test/unit/RemoteStream.php
@@ -8,6 +8,7 @@ final class RemoteStream
 {
     private $contents;
     private $position = 0;
+    public $context;
 
     function stream_open($path, $mode, $options, &$opened_path)
     {


### PR DESCRIPTION
Adds forward compatibility with v5 ciphertexts in v4. This (maybe) resolves #187.

In distributed environments where halite is used, it is pretty hard (impossible) to upgrade all services at the same time, when one service starts using halite v5, services using v4 can't understand what they're saying 😭 

All of the stuff here is copied over from v5 with minimal changes where needed.
I can try to provide some tests verifying that v4 indeed understands v5.