### PR TITLE
Use Psalm 6

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,13 +23,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: psalm:4
           coverage: none
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: --no-dev
 
-      - name: Static Analysis
-        run: psalm
+      - name: Psalm static analysis
+        run: vendor/bin/psalm

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9",
-        "vimeo/psalm": "^4"
+        "vimeo/psalm": "^6.8"
     },
     "scripts": {
         "test": "phpunit && phpstan && psalm"

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,10 +10,24 @@
         <PropertyNotSetInConstructor errorLevel="suppress" />
         <RedundantCondition errorLevel="suppress" />
         <RedundantConditionGivenDocblockType errorLevel="suppress" />
+        <UnusedClass errorLevel="suppress" />
+        <UnusedConstructor errorLevel="suppress" />
+        <UnusedParam errorLevel="suppress" />
+        <PossiblyUnusedMethod errorLevel="suppress" />
+        <PossiblyUnusedParam errorLevel="suppress" />
+        <PossiblyUnusedReturnValue errorLevel="suppress" />
 
         <TypeDoesNotContainType errorLevel="info" />
         <ArgumentTypeCoercion errorLevel="info" />
         <RedundantCast errorLevel="info" />
         <NonInvariantDocblockPropertyType errorLevel="info" />
+        <ClassMustBeFinal errorLevel="info" />
+        <MissingOverrideAttribute errorLevel="info" />
+        <RiskyTruthyFalsyComparison errorLevel="info" />
+        <InvalidFalsableReturnType errorLevel="info" />
+        <FalsableReturnStatement errorLevel="info" />
+        <PossiblyFalsePropertyAssignmentValue errorLevel="info" />
+        <PossiblyFalseArgument errorLevel="info" />
+        <PossiblyInvalidArrayAccess errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -100,7 +100,6 @@ final class Cookie
                 throw new InvalidType('Cookie value is not a string');
             }
             $config = self::getConfig($stored);
-            /** @var string|bool $encoding */
             $encoding = $config->ENCODING;
             $decrypted = Crypto::decrypt(
                 $stored,

--- a/src/Password.php
+++ b/src/Password.php
@@ -120,7 +120,6 @@ final class Password
         if (Binary::safeStrlen($stored) < ((int) $config->SHORTEST_CIPHERTEXT_LENGTH * 4 / 3)) {
             throw new InvalidMessage('Encrypted password hash is too short.');
         }
-        /** @var string|bool $encoding */
         $encoding = $config->ENCODING;
 
         // First let's decrypt the hash
@@ -225,7 +224,6 @@ final class Password
                 'Encrypted password hash is too short.'
             );
         }
-        /** @var string|bool $encoding */
         $encoding = $config->ENCODING;
 
         // First let's decrypt the hash

--- a/src/Stream/MutableFile.php
+++ b/src/Stream/MutableFile.php
@@ -217,7 +217,6 @@ class MutableFile implements StreamInterface
                 // @codeCoverageIgnoreEnd
             }
             $bufSize = min($remaining, self::CHUNK);
-            /** @var string|false $read */
             $read = fread($this->fp, $bufSize);
             if (!is_string($read)) {
                 // @codeCoverageIgnoreStart

--- a/src/Stream/ReadOnlyFile.php
+++ b/src/Stream/ReadOnlyFile.php
@@ -86,7 +86,6 @@ class ReadOnlyFile implements StreamInterface
                     'Could not open file for reading'
                 );
             }
-            /** @var resource|false $fp */
             $fp = fopen($file, 'rb');
             // @codeCoverageIgnoreStart
             if (!is_resource($fp)) {


### PR DESCRIPTION
Psalm has released version 6 and the development seems active again, so let's upgrade to the version 6.

I have suppressed _unused this and that_ errors as the methods are part of the API, and downgraded errors that maybe should be fixed one day to `errorLevel="info"`, but today is not the day. Wanted minimal changes for Psalm 6 to pass now.