### PR TITLE
Remove php 8.4 deprecations

### DIFF
--- a/src/Contract/StreamInterface.php
+++ b/src/Contract/StreamInterface.php
@@ -48,7 +48,7 @@ interface StreamInterface
 
     /**
      * Read from a stream; prevent partial reads
-     * 
+     *
      * @param int $num
      * @param bool $skipTests
      * @return string
@@ -63,14 +63,14 @@ interface StreamInterface
      * @return int
      */
     public function remainingBytes(): int;
-    
+
     /**
      * Write to a stream; prevent partial writes
-     * 
+     *
      * @param string $buf
-     * @param int $num (number of bytes)
+     * @param ?int $num (number of bytes)
      * @return int
      * @throws FileAccessDenied
      */
-    public function writeBytes(string $buf, int $num = null): int;
+    public function writeBytes(string $buf, ?int $num = null): int;
 }

--- a/src/File.php
+++ b/src/File.php
@@ -62,7 +62,7 @@ final class File
      * the BLAKE2b hash.
      *
      * @param string|resource|ReadOnlyFile $filePath
-     * @param Key $key (optional; expects SignaturePublicKey or
+     * @param ?Key $key (optional; expects SignaturePublicKey or
      *                  AuthenticationKey)
      * @param mixed $encoding Which encoding scheme to use for the checksum?
      * @return string         The checksum
@@ -77,7 +77,7 @@ final class File
      */
     public static function checksum(
         $filePath,
-        Key $key = null,
+        ?Key $key = null,
         $encoding = Halite::ENCODE_BASE64URLSAFE
     ): string {
         if ($filePath instanceof ReadOnlyFile) {
@@ -467,7 +467,7 @@ final class File
      * Calculate the BLAKE2b checksum of the contents of a file
      *
      * @param StreamInterface $fileStream
-     * @param Key $key
+     * @param ?Key $key
      * @param mixed $encoding Which encoding scheme to use for the checksum?
      * @return string
      *
@@ -482,7 +482,7 @@ final class File
      */
     protected static function checksumData(
         StreamInterface $fileStream,
-        Key $key = null,
+        ?Key $key = null,
         $encoding = Halite::ENCODE_BASE64URLSAFE
     ): string {
         $config = self::getConfig(

--- a/src/Stream/MutableFile.php
+++ b/src/Stream/MutableFile.php
@@ -226,10 +226,10 @@ class MutableFile implements StreamInterface
             )
         );
     }
-    
+
     /**
      * Set the current cursor position to the desired location
-     * 
+     *
      * @param int $i
      * @return bool
      * @throws CannotPerformOperation
@@ -257,7 +257,7 @@ class MutableFile implements StreamInterface
      * @throws FileAccessDenied
      * @throws \TypeError
      */
-    public function writeBytes(string $buf, int $num = null): int
+    public function writeBytes(string $buf, ?int $num = null): int
     {
         $bufSize = Binary::safeStrlen($buf);
         if (!\is_int($num) || $num > $bufSize) {

--- a/src/Stream/ReadOnlyFile.php
+++ b/src/Stream/ReadOnlyFile.php
@@ -74,7 +74,7 @@ class ReadOnlyFile implements StreamInterface
      * @throws \TypeError
      * @psalm-suppress RedundantConditionGivenDocblockType
      */
-    public function __construct($file, Key $key = null)
+    public function __construct($file, ?Key $key = null)
     {
         if (\is_string($file)) {
             if (!\is_readable($file)) {
@@ -331,11 +331,11 @@ class ReadOnlyFile implements StreamInterface
      * This is a meaningless operation for a Read-Only File!
      *
      * @param string $buf
-     * @param int $num (number of bytes)
+     * @param ?int $num (number of bytes)
      * @return int
      * @throws FileAccessDenied
      */
-    public function writeBytes(string $buf, int $num = null): int
+    public function writeBytes(string $buf, ?int $num = null): int
     {
         unset($buf);
         unset($num);

--- a/src/Symmetric/Crypto.php
+++ b/src/Symmetric/Crypto.php
@@ -437,7 +437,7 @@ final class Crypto
      * @param AuthenticationKey $secretKey
      * @param string $mac
      * @param mixed $encoding
-     * @param SymmetricConfig $config
+     * @param ?SymmetricConfig $config
      * @return bool
      *
      * @throws InvalidMessage
@@ -451,7 +451,7 @@ final class Crypto
         AuthenticationKey $secretKey,
         string $mac,
         $encoding = Halite::ENCODE_BASE64URLSAFE,
-        SymmetricConfig $config = null
+        ?SymmetricConfig $config = null
     ): bool {
         $decoder = Halite::chooseEncoder($encoding, true);
         if ($decoder) {


### PR DESCRIPTION
This PR addresses and removes deprecations related to PHP 8.4 within the halite library. With PHP 8.4's release on the horizon and its increasing adoption, ensuring forward compatibility is crucial for the continued stability and usability of this project.