### PR TITLE
Remove access modifier `final` from private methods

### DIFF
--- a/src/Asymmetric/Crypto.php
+++ b/src/Asymmetric/Crypto.php
@@ -60,7 +60,7 @@ final class Crypto
      * @throws Error
      * @codeCoverageIgnore
      */
-    final private function __construct()
+    private function __construct()
     {
         throw new Error('Do not instantiate');
     }

--- a/src/Halite.php
+++ b/src/Halite.php
@@ -66,7 +66,7 @@ final class Halite
      * @throws Error
      * @codeCoverageIgnore
      */
-    final private function __construct()
+    private function __construct()
     {
         throw new Error('Do not instantiate');
     }

--- a/src/Symmetric/Crypto.php
+++ b/src/Symmetric/Crypto.php
@@ -60,7 +60,7 @@ final class Crypto
      * @throws Error
      * @codeCoverageIgnore
      */
-    final private function __construct()
+    private function __construct()
     {
         throw new Error('Do not instantiate');
     }

--- a/src/Util.php
+++ b/src/Util.php
@@ -56,7 +56,7 @@ final class Util
      * @throws Error
      * @codeCoverageIgnore
      */
-    final private function __construct()
+    private function __construct()
     {
         throw new Error('Do not instantiate');
     }


### PR DESCRIPTION
Removes the access modifier `final` from private methods, as such methods are never overridden by other classes.