### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "paragonie/constant_time_encoding": "^2|^3",
-        "paragonie/hidden-string": "^1|^2",
-        "paragonie/sodium_compat": "^1|^2"
+        "paragonie/hidden-string": "^1|^2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^1|^2`, but also `php: ^8.1`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?